### PR TITLE
Add missing semicolon

### DIFF
--- a/style.css
+++ b/style.css
@@ -349,7 +349,7 @@ img {
   position: absolute;
   inset: auto;
   position-area: top span-left;
-  background: #31547a
+  background: #31547a;
   border: none;
   color: white;
   border-radius: 0.5rem;


### PR DESCRIPTION
Thanks for making this helpful tool! I noticed when I was using it that the tooltip on the IMCB checkbox didn't seem like it was working. It looks like a missing semicolon is causing the background to be white, which is the same color as the text.